### PR TITLE
copy over __name__ and __qualname__ when parsing function

### DIFF
--- a/memo/codegen.py
+++ b/memo/codegen.py
@@ -169,6 +169,8 @@ def _make_{f_name}():
     return _out_{f_name}
 
 {f_name} = _make_{f_name}()
+{f_name}.__name__ = '{f_name}'
+{f_name}.__qualname__ = '{pctxt.qualname}'
 """
 
     if debug_print_compiled:

--- a/memo/parse.py
+++ b/memo/parse.py
@@ -19,6 +19,7 @@ class ParsingContext:
     axes: list[tuple[str, str]]
     loc_name: str
     loc_file: str
+    qualname: str
 
 
 def ast_increment_colno(tree: ast.AST, n: int) -> None:
@@ -614,6 +615,7 @@ def parse_memo(ff: Callable[..., Any]) -> tuple[ParsingContext, list[Stmt], Expr
         axes=[],
         loc_name=f_name,
         loc_file=src_file,
+        qualname=ff.__qualname__
     )
     stmts: list[Stmt] = []
     retval = None


### PR DESCRIPTION
```python
@memo
def f():
    pass
```


Before:

```
>>> f
<function _make_f.<locals>._out_f at 0x126a18400>
```

After:
```
>>> f
<function f at 0x12de5c5e0>
```

I think the right way to do it is to use `functools.wraps`, but there seems to be data stashed in `f.__dict__` that I didn't want to touch. Anyways its a super minor cosmetic only change so feel free to discard this