### PR TITLE
Fix various incompatibilities with aux

### DIFF
--- a/memo/codegen.py
+++ b/memo/codegen.py
@@ -14,6 +14,8 @@ import linecache
 
 if TYPE_CHECKING:
     import jax
+    import pandas as pd
+    import xarray as xr
 
 from . import lib
 lib_dir = ', '.join([key for key in dir(lib) if not key.startswith('_')])
@@ -23,26 +25,117 @@ class MemoCompiled(Protocol):
     def __call__(
         self,
         *args: jax.typing.ArrayLike,
-        return_aux: Literal[False] = ...,
-        return_pandas: bool = ...,
-        return_xarray: bool = ...,
-        return_cost: bool = ...,
+        return_pandas: Literal[True],
+        return_xarray: Literal[True],
+        return_cost: Literal[True],
+        return_aux: bool = ...,
         print_table: bool = ...,
         **kwargs: jax.typing.ArrayLike
-    ) -> jax.Array:
+    ) -> memo_result[AuxInfo[float, pd.DataFrame, xr.DataArray]]:
         ...
 
     @overload
     def __call__(
         self,
         *args: jax.typing.ArrayLike,
-        return_aux: Literal[True] = ...,
-        return_pandas: bool = ...,
-        return_xarray: bool = ...,
-        return_cost: bool = ...,
+        return_pandas: Literal[True],
+        return_xarray: Literal[True],
+        return_aux: bool = ...,
+        return_cost: Literal[False] = ...,
         print_table: bool = ...,
         **kwargs: jax.typing.ArrayLike
-    ) -> memo_result:
+    ) -> memo_result[AuxInfo[float | None, pd.DataFrame, xr.DataArray]]:
+        ...
+
+    @overload
+    def __call__(
+        self,
+        *args: jax.typing.ArrayLike,
+        return_xarray: Literal[True],
+        return_cost: Literal[True],
+        return_aux: bool = ...,
+        return_pandas: Literal[False] = ...,
+        print_table: bool = ...,
+        **kwargs: jax.typing.ArrayLike
+    ) -> memo_result[AuxInfo[float, pd.DataFrame | None, xr.DataArray]]:
+        ...
+
+    @overload
+    def __call__(
+        self,
+        *args: jax.typing.ArrayLike,
+        return_pandas: Literal[True],
+        return_cost: Literal[True],
+        return_aux: bool = ...,
+        return_xarray: Literal[False] = ...,
+        print_table: bool = ...,
+        **kwargs: jax.typing.ArrayLike
+    ) -> memo_result[AuxInfo[float, pd.DataFrame, xr.DataArray | None]]:
+        ...
+
+    @overload
+    def __call__(
+        self,
+        *args: jax.typing.ArrayLike,
+        return_pandas: Literal[True],
+        return_aux: bool = ...,
+        return_xarray: Literal[False] = ...,
+        return_cost: Literal[False] = ...,
+        print_table: bool = ...,
+        **kwargs: jax.typing.ArrayLike
+    ) -> memo_result[AuxInfo[float | None, pd.DataFrame, xr.DataArray | None]]:
+        ...
+
+    @overload
+    def __call__(
+        self,
+        *args: jax.typing.ArrayLike,
+        return_xarray: Literal[True],
+        return_aux: bool = ...,
+        return_pandas: Literal[False] = ...,
+        return_cost: Literal[False] = ...,
+        print_table: bool = ...,
+        **kwargs: jax.typing.ArrayLike
+    ) -> memo_result[AuxInfo[float | None, pd.DataFrame | None, xr.DataArray]]:
+        ...
+
+    @overload
+    def __call__(
+        self,
+        *args: jax.typing.ArrayLike,
+        return_cost: Literal[True],
+        return_aux: bool = ...,
+        return_pandas: Literal[False] = ...,
+        return_xarray: Literal[False] = ...,
+        print_table: bool = ...,
+        **kwargs: jax.typing.ArrayLike
+    ) -> memo_result[AuxInfo[float, pd.DataFrame | None, xr.DataArray | None]]:
+        ...
+
+    @overload
+    def __call__(
+        self,
+        *args: jax.typing.ArrayLike,
+        return_aux: Literal[True],
+        return_pandas: Literal[False] = ...,
+        return_xarray: Literal[False] = ...,
+        return_cost: Literal[False] = ...,
+        print_table: bool = ...,
+        **kwargs: jax.typing.ArrayLike
+    ) -> memo_result[AuxInfo[float | None, pd.DataFrame | None, xr.DataArray | None]]:
+        ...
+
+    @overload
+    def __call__(
+        self,
+        *args: jax.typing.ArrayLike,
+        return_aux: Literal[False] = ...,
+        return_pandas: Literal[False] = ...,
+        return_xarray: Literal[False] = ...,
+        return_cost: Literal[False] = ...,
+        print_table: bool = ...,
+        **kwargs: jax.typing.ArrayLike
+    ) -> jax.Array:
         ...
 
     def __call__(
@@ -54,7 +147,7 @@ class MemoCompiled(Protocol):
         return_cost: bool = False,
         print_table: bool = False,
         **kwargs: jax.typing.ArrayLike
-    ) -> jax.Array | memo_result:
+    ) -> jax.Array | memo_result[AuxInfo[float | None, pd.DataFrame | None, xr.DataArray | None]]:
         ...
 
 def make_static_parameter_list(pctxt: ParsingContext) -> str:

--- a/memo/core.py
+++ b/memo/core.py
@@ -28,14 +28,19 @@ except ImportError:  # Graceful fallback if IceCream isn't installed.
     ic = lambda *a: None if not a else (a[0] if len(a) == 1 else a)  # noqa
 
 @dataclass
-class AuxInfo:
-    cost: float | None = None
-    pandas: pd.DataFrame | None = None
-    xarray: xr.DataArray | None = None
+class AuxInfo[
+    CostT = float | None,
+    PandasT = pd.DataFrame | None,
+    XArrayT = xr.DataArray | xr.Dataset | None,
+]:
+    cost: CostT = None  # type: ignore[assignment]
+    pandas: PandasT = None  # type: ignore[assignment]
+    xarray: XArrayT = None  # type: ignore[assignment]
 
-class memo_result(NamedTuple):
+
+class memo_result[AuxT = AuxInfo](NamedTuple):
     data: jax.Array
-    aux: AuxInfo
+    aux: AuxT
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## 1. xarray/pandas aux flags raised errors in multi-return memos

### Previous behavior

Both `return_xarray` and `return_pandas` errored when a memo had multiple return statements.

```python
import jax.numpy as jnp
from memo import memo

N = jnp.arange(5)
M = jnp.arange(3)

@memo
def multi[_n: N, _m: M]():
    agent: chooses(n in N, m in M, wpp=1)
    return Pr[agent.n == _n]
    return Pr[agent.m == _m]
    return E[agent.n + agent.m]

multi(return_xarray=True)
# CoordinateValidationError: coordinate _n has dimensions ('_n',),
#   but these are not a subset of the DataArray dimensions ('dim_0', 'dim_1', 'dim_2')

multi(return_pandas=True)
# ValueError: can only convert an array of size 1 to a Python scalar
```

The array returned by a multi-return memo has shape `(num_retvals, *dims)`. This was passed directly to `xr.DataArray(data=z, coords=coords)`, but `coords` only accounts for the forall dimensions `(_n, _m)`, not the leading retval axis.

The pandas code indexed `z[idx]`, where `idx` is a forall coordinate, which was similarly incompatible with multi-return arrays.

### Changes

xarray now returns an `xr.Dataset` with one `DataArray` per return value. pandas returns a `DataFrame` with one value column per return value. Both use the `funcname[i]` naming convention from `pprint_table`.

```python
xa = multi(return_xarray=True).aux.xarray
list(xa.data_vars)                       # ['multi[0]', 'multi[1]', 'multi[2]']
xa['multi[0]'].shape                     # (5, 3)
xa['multi[0]'].dims                      # ('_n', '_m')

df = multi(return_pandas=True).aux.pandas
list(df.columns)                         # ['_n', '_m', 'multi[0]', 'multi[1]', 'multi[2]']
df.shape                                 # (15, 5)
```

Single-return memos are unchanged: xarray returns a `DataArray`, pandas returns a `DataFrame` with one value column.

**`memo/lib.py` — `make_xarray_data`:** For multi-return memos, returns an `xr.Dataset` with one named `DataArray` per return value instead of passing the full `(num_retvals, *dims)` array to a single `DataArray`.

**`memo/lib.py` — `make_pandas_data`:** Indexes into the leading retval axis with `z[(k,) + idx]` for each return value `k`, producing one value column per return value instead of calling `.item()` on a non-scalar slice.

---

## 2. marginalized forall axes not communicated to xarray, resulting in errors

### Previous behavior

When a memo marginalized over independent axes and returned an array smaller than the query variables:

- pandas handled it implicitly (iterated the full coordinate space and indexed into the broadcast array).
- xarray expected exact shape agreement between data and coordinates, producing an error.

```python
import jax.numpy as jnp
from memo import memo

Action = jnp.arange(3)
Outcome = jnp.arange(2)

@memo
def unused[_a: Action, _o: Outcome]():
    alice: knows(_a, _o)
    alice: thinks[
        bob: knows(_a, _o),
        bob: thinks[
            carol: chooses(x in Action, wpp=1),
            carol: given(result in Outcome, wpp=(0.1 + 0.3*x) if result == 1 else 9),
        ],
        bob: observes [carol.x] is _a,
    ]
    return alice[bob[Pr[carol.result == _a]]]

unused().shape                     # (3, 1) — _o axis is size-1
unused(return_xarray=True)
# CoordinateValidationError: conflicting sizes for dimension '_o':
#   length 1 on the data but length 2 on coordinate '_o'
```

The model returns an array of shape `(3, 1)` instead of `(3, 2)`. `make_xarray_data` passing this to `xr.DataArray(data=z, coords={'_a': [0,1,2], '_o': [0,1]})` produced an error.

### Changes

```python
unused().shape                              # (3, 1) — raw output unchanged

xa = unused(return_xarray=True).aux.xarray
xa.dims                                     # ('_a', '_o')
xa.sizes                                    # {'_a': 3, '_o': 2}
jnp.allclose(xa.values, jnp.broadcast_to(unused(), (3, 2)))  # True
```

**`memo/lib.py` — `make_xarray_data`:** Added `z = jnp.broadcast_to(z, f._shape)` before constructing the `DataArray`. This expands size-1 axes to match the declared coordinate lengths.

The updated code also passes `dims=` explicitly to the `DataArray` constructor. Previously, dimension names were derived from `coords` ordering, which produced incorrect generic names (`dim_0`, `dim_1`) when the data shape didn't match the coordinate lengths.

---

## 3. Type narrowing for aux return fields

### Previous behavior

The `MemoCompiled` protocol had two overloads: `return_aux=False` -> `jax.Array`, `return_aux=True` -> `memo_result`. This worked for a while but the behavior degraded with recent language servers[^1]. In addition, requiring `return_aux=True` was redundant but required[^2].

[^1]: The aux fields were typed as nullable (`DataFrame | None`, `DataArray | None`) because `AuxInfo` was not generic — there was no way to express that the requested field was guaranteed to be populated. Any method call on the result (e.g. `.head()`, `.dims`) required a None guard.

[^2]: Passing `return_pandas=True` without `return_aux=True` matched the `return_aux=False` overload and typed the result as `jax.Array`, even though at runtime the codegen set `return_aux = True` when any output flag was set.


```python
# pyright 1.1.408 on upstream:

r = model(return_pandas=True)
# type: Array                          <- runtime returns memo_result
r.aux.pandas
# error: Cannot access attribute "aux" for class "Array"

r = model(return_aux=True, return_pandas=True)
r.aux.pandas
# type: DataFrame | None               <- nullable despite explicit request
r.aux.pandas.head()
# error: "head" is not a known attribute of "None"

r = model(return_aux=True, return_xarray=True)
r.aux.xarray
# type: DataArray | None               <- same problem
r.aux.xarray.dims
# error: "dims" is not a known attribute of "None"
```

The same errors appear in ty 0.0.17 (9 `unresolved-attribute` errors). 

FYI mypy 1.19.1 reports `Any` for all types due to wildcard imports in `codegen.py`. PEP 563 turns all annotations into strings for lazy evaluation, and mypy does not resolve wildcard-imported names when evaluating those string annotations — it reports `Name "memo_result" is not defined` for every name from `core` and `parse` (19 errors on upstream, 35 with the additional overloads here). Replacing the wildcards with explicit imports would fix this. I'm happy to add that to the PR if you think it's useful.

### Changes

`AuxInfo` and `memo_result` are now generic. The `MemoCompiled` protocol has overloads for each combination of `(return_pandas, return_xarray, return_cost)`, with `Literal[True]` parameters declared without defaults so they only match when explicitly passed. Thus, passing any output flag implicitly returns a `memo_result` and `return_aux` is no longer the primary dispatch mechanism.

```python
# pyright 1.1.408 on fixed (0 errors):

r = model()
# type: Array                          ✓

r = model(return_pandas=True)
# type: memo_result[AuxInfo[float | None, DataFrame, DataArray | None]]
r.aux.pandas
# type: DataFrame                      ✓ narrowed, no None

r = model(return_xarray=True)
# type: memo_result[AuxInfo[float | None, DataFrame | None, DataArray]]
r.aux.xarray
# type: DataArray                      ✓ narrowed, no None

r = model(return_cost=True)
# type: memo_result[AuxInfo[float, DataFrame | None, DataArray | None]]
r.aux.cost
# type: float                          ✓ narrowed, no None

r = model(return_pandas=True, return_xarray=True, return_cost=True)
# type: memo_result[AuxInfo[float, DataFrame, DataArray]]
r.aux.pandas                           # DataFrame
r.aux.xarray                           # DataArray
r.aux.cost                             # float

r = model(return_aux=True)
# type: memo_result[AuxInfo[float | None, DataFrame | None, DataArray | None]]
# all fields correctly nullable — no specific data was requested
```

ty 0.0.17 produces equivalent results (0 errors). mypy 1.19.1 is unaffected (same pre-existing wildcard-import issue).

`return_aux` remains functional and backwards-compatible but is no longer necessary when using `return_pandas`, `return_xarray`, or `return_cost`.

**`memo/core.py` — `AuxInfo`:** Made generic with three type parameters (`CostT`, `PandasT`, `XArrayT`), each defaulting to the nullable union. The `# type: ignore[assignment]` on the field defaults is necessary because `None` is not assignable to the generic type in the general case; the `MemoCompiled` overloads ensure the concrete types always match at call sites.

**`memo/core.py` — `memo_result`:** Made generic over `AuxT` (defaulting to `AuxInfo`) so that narrowed `AuxInfo` parameterizations propagate through the return type.

**`memo/codegen.py` — `MemoCompiled`:** overloads covering all combinations of `(return_pandas, return_xarray, return_cost)` plus `return_aux=True` alone.